### PR TITLE
Update books.show logic to support filtering

### DIFF
--- a/app/Http/Controllers/BooksController.php
+++ b/app/Http/Controllers/BooksController.php
@@ -18,7 +18,7 @@ class BooksController extends Controller
   public function index()
   {
 
-   $books = Book::with('Author')->with('Genre')->orderByDesc('date_read')->paginate(10);
+    $books = Book::with('Author')->with('Genre')->orderByDesc('date_read')->paginate(10);
 
     return view('books.index', compact(['books']));
   }
@@ -87,13 +87,39 @@ class BooksController extends Controller
   }
 
   /**
-   * Display the specified resource.
+   * Display the specified book record based on ID.
+   *   If the ID starts with a letter, display a filtered list
+   *   of Genre, Owned, or Series
    *
    * @param  int  $id
    * @return \Illuminate\Http\Response
    */
   public function show($id)
   {
+    $filter = substr( $id, 0, 1); 
+    if ($filter == 's' || $filter == 'g' || $filter == 'o')
+
+       {
+        switch ($filter) {
+        case "g":
+          $dbfilter = 'genre_id';
+          break;
+        case "o":
+          $dbfilter = 'owned_id';
+          break;
+        case "s":
+          $dbfilter = 'series_id';
+          break;
+        }
+
+          $books = Book::with('Author')->with('Genre')->
+          where($dbfilter , "=", substr( $id, 1))->
+          orderByDesc('date_read')->paginate(10);
+
+          return view('books.index', compact(['books']));      
+
+       } else
+       {
     $book = Book::FindOrFail($id);
 
     // If ISBN is blank, show the "missing" book cover    
@@ -121,6 +147,8 @@ class BooksController extends Controller
     }
 
     return view('books.show', compact('book', 'bk_coauth', 'bkurl', 'bk_series'));
+  }
+
   }
 
   /**
@@ -244,5 +272,28 @@ class BooksController extends Controller
 
     // redirect user and send status
     return redirect()->route('Books.index')->with('success', 'Book record deleted successfully');
+  }
+
+  /**
+   * Re-use the existing Index view to present a
+   *  filtered list of books.
+   *
+   * @return \Illuminate\Http\Response
+   */
+  public function filter($filter)
+  {
+
+    return 'Filter function called';
+
+  //   $col = substr($filter,0,1);
+  //   $colindex = ltrim($filter,$col);
+
+  //   return 'Index table '.$col.' lookup ='.$colindex;
+
+  // $books = Book::with('Author')->with('Genre')
+  //   ->where('author_id', '=', "15")
+  //   ->orderByDesc('date_read')->paginate(10);
+
+  //   return view('books.index', compact(['books']));
   }
 }

--- a/app/Http/Livewire/LWSeries.php
+++ b/app/Http/Livewire/LWSeries.php
@@ -5,9 +5,14 @@ namespace App\Http\Livewire;
 use Livewire\Component;
 use App\Models\series;
 use App\Models\book;
+use Livewire\WithPagination;
 
 class LWSeries extends Component
 {
+    Use WithPagination;
+    
+    protected $paginationTheme = 'bootstrap';
+
     public $seriesID = 1;
     public $seriesName = "";
     public $showaddSeriesmodal = true;
@@ -15,7 +20,7 @@ class LWSeries extends Component
 
     public function render()
     {
-        $series_book_count = series::select("id", "series")->withCount('book')->orderby('series')->get();
+        $series_book_count = series::select("id", "series")->withCount('book')->orderby('series')->paginate(10);
 
         return view('livewire.l-w-series', compact(['series_book_count']));
     }
@@ -38,6 +43,16 @@ class LWSeries extends Component
         ]);
         session()->flash('message', 'New Series record created');
         return redirect()->to('/Series');
+    }
+
+    // Redirect the viewer to the Books view with
+    //  a filter based on the series # 
+    public function seriesShow(int $seriesID)
+    {
+        $this->seriesID = $seriesID;
+
+        return redirect()->to('/Books/s' . $seriesID);
+
     }
 
     // Display the current genre name for editing

--- a/resources/views/livewire/l-w-series.blade.php
+++ b/resources/views/livewire/l-w-series.blade.php
@@ -16,8 +16,8 @@
                     </div>
                     <div class="col-med-4 col-lg-4">
                         <div class="pull-right">
-                            <button type="button" class="btn btn-primary mt-2 mb-2" data-bs-toggle="modal"
-                                data-bs-target="#addSeriesModal">Create New series</button>
+                            <button type="button" class="btn btn-success mt-2 mb-2" data-bs-toggle="modal"
+                                data-bs-target="#addSeriesModal">Create new Series</button>
                         </div>
                     </div>
                 </div>
@@ -28,22 +28,25 @@
                 </div>
                 @endif
 
-                <table class="table table-bordered border-dark table-striped">
+                <table class="table table-bordered border-dark table-striped table-sm">
                     {{-- Check if no series records returned --}}
                     @if(empty($series_book_count))
                     @else
                     <tr>
                         <th>Series</th>
                         <th width="100px">Book count</th>
-                        <th width="200px">Action</th>
+                        <th  class=text-center width="240px">Action</th>
                     </tr>
                     @endif
 
                     @forelse ($series_book_count as $series)
                     <tr>
                         <td>{{$series->series }}</td>
-                        <td>{{$series->book_count }}</td>
-                        <td>
+                        <td class=text-center>{{$series->book_count }}</td>
+                        <td class=text-center>
+                            <button type="button" wire:click.prevent="seriesShow({{$series->id}})"
+                                class="btn btn-primary mt-1" data-bs-toggle="modal" data-bs-target="">
+                                Show</button>
                             <button type="button" wire:click.prevent="seriesEdit({{$series->id}})"
                                 class="btn btn-warning mt-1" data-bs-toggle="modal" data-bs-target="#editSeriesModal">
                                 Edit</button>
@@ -53,10 +56,11 @@
                         </td>
                     </tr>
                     @empty
-                    <h1>No series created - please add one.</h1>
+                    {{-- <h1>No series created - please add one.</h1> --}}
                     @endforelse
 
                 </table>
+                {{$series_book_count->links()}}
             </div>
             <div class="col-med-3 col-lg-3">
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,10 +19,12 @@ use Illuminate\Support\Facades\Route;
 
 Route::get('/',        [PagesController::class,'index']);
 Route::get('/home',    [PagesController::class,'home']);
-Route::get('/authors', [PagesController::class,'authors']);
-Route::get('/genres',  [PagesController::class,'genres']);
-Route::get('/series',  [PagesController::class,'series']);
-Route::get('/owned',   [PagesController::class,'owned']);
+// Route::get('/authors', [PagesController::class,'authors']);
+// Route::get('/genres',  [PagesController::class,'genres']);
+// Route::get('/series',  [PagesController::class,'series']);
+// Route::get('/owned',   [PagesController::class,'owned']);
+
+// Route::get('/Books/filter', [BooksController::class, 'filter']);
 
 Route::get('/LWAuthors', function (){
     return view('authors.lwauth');


### PR DESCRIPTION
Added changes to books.show to allow filtering of Series, Genres, and Owned Status.

- Addition of Show button to main display for Series #10 
- Addition of pagination to the Series main display #18
- Case statement added to Books.Show to handle the "show" requests from the main Series, Genres #7 #8, and Owned Status pages #35 
