### PR TITLE
Save the return URL when called from primary book element displays

### DIFF
--- a/app/Http/Livewire/LWGenres.php
+++ b/app/Http/Livewire/LWGenres.php
@@ -3,19 +3,32 @@
 namespace App\Http\Livewire;
 
 use Livewire\Component;
+use Illuminate\Support\Facades\Session;
 use App\Models\genre;
 use App\Models\book;
+use Livewire\WithPagination;
 
 class LWGenres extends Component
 {
+    use WithPagination;
+
+    protected $paginationTheme = 'bootstrap';
+
     public $genreID = 1;
     public $genreName = "";
     public $showaddGenremodal = true;
     public $showeditGenremodal = true;
 
+public function mount()
+{
+        Session::forget('book_url');
+
+}
     public function render()
     {
-        $genre_book_count = genre::select("id", "genre")->withCount('book')->orderby('genre')->get();
+
+        $genre_book_count = genre::select("id", "genre")->withCount('book')
+            ->orderby('genre')->paginate(10);
 
         return view('livewire.l-w-genres', compact(['genre_book_count']));
     }
@@ -38,6 +51,15 @@ class LWGenres extends Component
         ]);
         session()->flash('message', 'New Genre record created');
         return redirect()->to('/Genres');
+    }
+
+    // Redirect the viewer to the Books view with
+    //  a filter based on the genre # 
+    public function genreShow(int $genreID)
+    {
+        $this->genreID = $genreID;
+
+        return redirect()->to('/Books/g' . $genreID);
     }
 
     // Display the current genre name for editing

--- a/app/Http/Livewire/LWOwnedStatus.php
+++ b/app/Http/Livewire/LWOwnedStatus.php
@@ -5,17 +5,28 @@ namespace App\Http\Livewire;
 use Livewire\Component;
 use App\Models\owned;
 use App\Models\book;
+use Livewire\WithPagination;
+use Illuminate\Support\Facades\Session;
 
 class LWOwnedStatus extends Component
 {
+    Use WithPagination;
+    
+    protected $paginationTheme = 'bootstrap';
+
     public $ownedstatusID = 1;
     public $ownedstatusName = "";
     public $showaddOwnedmodal = true;
     public $showeditOwnedmodal = true;
 
-    public function render()
+    public function mount()
     {
-        $ownedstatus_book_count = owned::select("id", "owned_status")->withCount('book')->orderby('owned_status')->get();
+            Session::forget('book_url');
+    
+    }    public function render()
+    {
+        $ownedstatus_book_count = owned::select("id", "owned_status")->withCount('book')->
+        orderby('owned_status')->paginate(10);
 
         return view('livewire.l-w-owned-status', compact(['ownedstatus_book_count']));
     }
@@ -38,6 +49,16 @@ class LWOwnedStatus extends Component
         ]);
         session()->flash('message', 'New Owned Status record created');
         return redirect()->to('/Owned');
+    }
+
+    // Redirect the viewer to the Books view with
+    //  a filter based on the OwnedStatus # 
+    public function ownedstatusShow(int $ownedstatusID)
+    {
+        $this->ownedstatusID = $ownedstatusID;
+
+        return redirect()->to('/Books/o' . $ownedstatusID);
+
     }
 
     // Display the current genre name for editing

--- a/app/Http/Livewire/LWSeries.php
+++ b/app/Http/Livewire/LWSeries.php
@@ -6,6 +6,7 @@ use Livewire\Component;
 use App\Models\series;
 use App\Models\book;
 use Livewire\WithPagination;
+use Illuminate\Support\Facades\Session;
 
 class LWSeries extends Component
 {
@@ -18,7 +19,12 @@ class LWSeries extends Component
     public $showaddSeriesmodal = true;
     public $showeditSeriesmodal = true;
 
-    public function render()
+    public function mount()
+    {
+            Session::forget('book_url');
+    
+    }
+        public function render()
     {
         $series_book_count = series::select("id", "series")->withCount('book')->orderby('series')->paginate(10);
 

--- a/resources/views/books/edit.blade.php
+++ b/resources/views/books/edit.blade.php
@@ -11,9 +11,10 @@
     <div class="col-lg-5">
       <div class="pull-left">
         <h2>Edit a book</h2>
+        
       </div>
       <div class="pull-right">
-        <a class="btn btn-primary" href="{{ URL::previous() }}"> Back</a>
+        <a class="btn btn-primary" href="{{session('book_url')}}"> Back</a>
       </div>
     </div>
     <div class="col-lg-6">

--- a/resources/views/books/show.blade.php
+++ b/resources/views/books/show.blade.php
@@ -18,7 +18,7 @@
   </div>
   <div class="col-lg-4 col-med-4">
       <div class="pull-right">
-        <a class="btn btn-primary" href="{{ route('Books.index') }}"> Back</a>
+        <a class="btn btn-primary" href="{{ session('book_url') }}"> Back</a>
       </div>
    </div>
    <div class="col-lg-5 col-med-2">

--- a/resources/views/livewire/l-w-genres.blade.php
+++ b/resources/views/livewire/l-w-genres.blade.php
@@ -16,7 +16,8 @@
                     </div>
                     <div class="col-med-4 col-lg-4">
                         <div class="pull-right">
-                            <button type="button" class="btn btn-primary mt-2 mb-2" data-bs-toggle="modal" data-bs-target="#addGenreModal">Create New Genre</button>
+                            <button type="button" class="btn btn-success mt-2 mb-2" data-bs-toggle="modal"
+                                data-bs-target="#addGenreModal">Create new Genre</button>
                         </div>
                     </div>
                 </div>
@@ -31,15 +32,16 @@
                     <tr>
                         <th>Genre</th>
                         <th width="100px">Book count</th>
-                        <th width="200px">Action</th>
+                        <th class=text-center width="180px">Label Action</th>
+                        <th width="150px"></th>
                     </tr>
 
                     @foreach ($genre_book_count as $genre)
                     <tr>
                         <td>{{$genre->genre }}</td>
-                        <td>{{$genre->book_count }}</td>
-                        <td>
-                            <button type="button" wire:click.prevent="genreEdit({{$genre->id}})"
+                        <td class=text-center>{{$genre->book_count }}</td>
+                        <td class=text-center>
+                             <button type="button" wire:click.prevent="genreEdit({{$genre->id}})"
                                 class="btn btn-warning mt-1 @if ($genre->id == 1) disabled  @endif "
                                 data-bs-toggle="modal" data-bs-target="#editGenreModal">
                                 Edit</button>
@@ -48,10 +50,16 @@
                                 data-bs-toggle="modal" data-bs-target="#deleteGenreModal">
                                 Delete</button>
                         </td>
+                        <td>
+                            <button type="button" wire:click.prevent="genreShow({{$genre->id}})"
+                                class="btn btn-primary mt-1" data-bs-toggle="modal" data-bs-target="">
+                                Show Books</button>
+                        </td>
                     </tr>
                     @endforeach
 
                 </table>
+                {{$genre_book_count->links()}}
             </div>
             <div class="col-med-3 col-lg-3">
             </div>

--- a/resources/views/livewire/l-w-owned-status.blade.php
+++ b/resources/views/livewire/l-w-owned-status.blade.php
@@ -16,8 +16,8 @@
                     </div>
                     <div class="col-med-5 col-lg-5">
                         <div class="pull-right">
-                            <button type="button" class="btn btn-primary mt-2 mb-2" data-bs-toggle="modal"
-                                data-bs-target="#addOwnedStatusModal">Create New owned status</button>
+                            <button type="button" class="btn btn-success mt-2 mb-2" data-bs-toggle="modal"
+                                data-bs-target="#addOwnedStatusModal">Create new Owned Status</button>
                         </div>
                     </div>
                 </div>
@@ -35,21 +35,30 @@
                     <tr>
                         <th>Owned Status</th>
                         <th width="100px">Book count</th>
-                        <th width="200px">Action</th>
+                        <th class=text-center width="180px">Label Action</th>
+                        <th width="150px"> </th>
                     </tr>
                     @endif
 
                     @forelse ($ownedstatus_book_count as $ownedstatus)
                     <tr>
-                        <td>{{$ownedstatus->owned_status }}</td>
-                        <td>{{$ownedstatus->book_count }}</td>
-                        <td>
+                        <td>{{$ownedstatus->owned_status }}
+                        </td>
+                        <td class=text-center>{{$ownedstatus->book_count }}</td>
+                        <td class=text-center>
                             <button type="button" wire:click.prevent="ownedstatusEdit({{$ownedstatus->id}})"
-                                class="btn btn-warning mt-1" data-bs-toggle="modal" data-bs-target="#editOwnedStatusModal">
+                                class="btn btn-warning mt-1" data-bs-toggle="modal"
+                                data-bs-target="#editOwnedStatusModal">
                                 Edit</button>
                             <button type="button" wire:click.prevent="ownedstatusDelLookup({{$ownedstatus->id}})"
-                                class="btn btn-danger mt-1" data-bs-toggle="modal" data-bs-target="#deleteOwnedStatusModal">
+                                class="btn btn-danger mt-1" data-bs-toggle="modal"
+                                data-bs-target="#deleteOwnedStatusModal">
                                 Delete</button>
+                        </td>
+                        <td class=text-center>
+                            <button type="button" wire:click.prevent="ownedstatusShow({{$ownedstatus->id}})"
+                                class="btn btn-primary mt-1" data-bs-toggle="modal" data-bs-target="">
+                                Show Books</button>
                         </td>
                     </tr>
                     @empty
@@ -57,6 +66,7 @@
                     @endforelse
 
                 </table>
+                {{$ownedstatus_book_count->links()}}
             </div>
             <div class="col-med-3 col-lg-3">
             </div>

--- a/resources/views/livewire/l-w-series.blade.php
+++ b/resources/views/livewire/l-w-series.blade.php
@@ -35,7 +35,8 @@
                     <tr>
                         <th>Series</th>
                         <th width="100px">Book count</th>
-                        <th  class=text-center width="240px">Action</th>
+                        <th class=text-center width="180px">Label Action</th>
+                        <th width="150px"> </th>
                     </tr>
                     @endif
 
@@ -44,9 +45,6 @@
                         <td>{{$series->series }}</td>
                         <td class=text-center>{{$series->book_count }}</td>
                         <td class=text-center>
-                            <button type="button" wire:click.prevent="seriesShow({{$series->id}})"
-                                class="btn btn-primary mt-1" data-bs-toggle="modal" data-bs-target="">
-                                Show</button>
                             <button type="button" wire:click.prevent="seriesEdit({{$series->id}})"
                                 class="btn btn-warning mt-1" data-bs-toggle="modal" data-bs-target="#editSeriesModal">
                                 Edit</button>
@@ -54,6 +52,12 @@
                                 class="btn btn-danger mt-1" data-bs-toggle="modal" data-bs-target="#deleteSeriesModal">
                                 Delete</button>
                         </td>
+                        <td class=text-center>
+                            <button type="button" wire:click.prevent="seriesShow({{$series->id}})"
+                                class="btn btn-primary mt-1" data-bs-toggle="modal" data-bs-target="">
+                                Show Books</button>
+                        </td>
+
                     </tr>
                     @empty
                     {{-- <h1>No series created - please add one.</h1> --}}


### PR DESCRIPTION
Updates the Genres, Owned Status, and Series pages so that the URL of starting page (ie Aliens series, or Historical books) is used when completing a record update or the Back button #17.  These pages now include pagination (#40 #41) to make better navigation as the lists grow longer. 

