### PR TITLE
Enable editing for 1st genre

### DIFF
--- a/resources/views/livewire/l-w-genres.blade.php
+++ b/resources/views/livewire/l-w-genres.blade.php
@@ -42,7 +42,7 @@
                         <td class=text-center>{{$genre->book_count }}</td>
                         <td class=text-center>
                              <button type="button" wire:click.prevent="genreEdit({{$genre->id}})"
-                                class="btn btn-warning mt-1 @if ($genre->id == 1) disabled  @endif "
+                                class="btn btn-warning mt-1"
                                 data-bs-toggle="modal" data-bs-target="#editGenreModal">
                                 Edit</button>
                             <button type="button" wire:click.prevent="genreDelLookup({{$genre->id}})"


### PR DESCRIPTION
- Fixed incorrect setting of the Edit button to disabled #44.  The first genre will always be prevented from getting deleted, but the user can change the name.
